### PR TITLE
fix extraction of access token from API response

### DIFF
--- a/lib/facebook_test_users/access_token.rb
+++ b/lib/facebook_test_users/access_token.rb
@@ -23,10 +23,7 @@ module FacebookTestUsers
     private
 
     def self.extract_access_token(response_body)
-      response_body.
-        match(/=(.*)/).     # response is a string like "access_token=bunch-o-crap"
-        captures[0].
-        strip
+      JSON.parse(response_body)["access_token"]
     end
 
   end


### PR DESCRIPTION
Presumably something changed in the last 5 years in the way the Facebook API responds, so properly parse the response body as JSON rather than using some very brittle string parsing.